### PR TITLE
(tf-gcloud): Do not launch browser when logging in

### DIFF
--- a/base/tf-gcloud.mk
+++ b/base/tf-gcloud.mk
@@ -34,6 +34,10 @@ _GCLOUD  = gcloud
 ################################################################################################
 #                                             VARIABLES
 
+### gcloud options
+
+GCLOUD_LAUNCH_BROWSER     ?= false
+
 ### Google Cloud Platform
 
 GCP_DEFAULT_CONFIGURATION  = default
@@ -111,7 +115,11 @@ _init-gcp-project:
 		read -p "$(__BOLD)$(__MAGENTA)Default project: $${_DEFAULT_PROJECT}, current project: $${_CURRENT_PROJECT}. Do you want to switch project? [y/Y]: $(__RESET)" ANSWER && \
 		if [ "$${ANSWER}" = "y" ] || [ "$${ANSWER}" = "Y" ]; then \
 			$(_GCLOUD) config set project $(GCP_PROJECT) && \
-			$(_GCLOUD) auth login --update-adc ; \
+			if [ "$(GCLOUD_LAUNCH_BROWSER)" = "true" ]; then \
+				$(_GCLOUD) auth login --brief --update-adc; \
+			else \
+				$(_GCLOUD) auth login --no-launch-browser --update-adc ; \
+			fi; \
 			printf "$(__BOLD)$(__GREEN)Project changed to $(GCP_PROJECT)$(__RESET)\n"; \
 		else \
 			printf "$(__BOLD)$(__CYAN)Using project ($${_CURRENT_PROJECT})$(__RESET)\n"; \
@@ -121,14 +129,22 @@ _init-gcp-project:
 		[ ! "$(NON_INTERACTIVE)" = "true" ] && \
 		read -p "$(__BOLD)$(__MAGENTA)Do you want to re-login and update ADC with ($${_DEFAULT_PROJECT}) project? [y/Y]: $(__RESET)" ANSWER && \
 		if [ "$${ANSWER}" = "y" ] || [ "$${ANSWER}" = "Y" ]; then \
-			$(_GCLOUD) auth login --update-adc ; \
+			if [ "$(GCLOUD_LAUNCH_BROWSER)" = "true" ]; then \
+				$(_GCLOUD) auth login --brief --update-adc; \
+			else \
+				$(_GCLOUD) auth login --no-launch-browser --update-adc ; \
+			fi; \
 		fi; \
 		printf "$(__BOLD)$(__CYAN)Project is set to ($${_CURRENT_PROJECT})$(__RESET)\n"; \
 	else \
 		[ ! "$(NON_INTERACTIVE)" = "true" ] && \
 		read -p "$(__BOLD)$(__MAGENTA)Do you want to re-login and update ADC with ($${_CURRENT_PROJECT}) project? [y/Y]: $(__RESET)" ANSWER && \
 		if [ "$${ANSWER}" = "y" ] || [ "$${ANSWER}" = "Y" ]; then \
-			$(_GCLOUD) auth login --update-adc ; \
+			if [ "$(GCLOUD_LAUNCH_BROWSER)" = "true" ]; then \
+				$(_GCLOUD) auth login --brief --update-adc; \
+			else \
+				$(_GCLOUD) auth login --no-launch-browser --update-adc ; \
+			fi; \
 		fi; \
 		printf "$(__BOLD)$(__CYAN)Project is set to ($${_CURRENT_PROJECT})$(__RESET)\n"; \
 	fi

--- a/terraform-gcp/Makefile
+++ b/terraform-gcp/Makefile
@@ -63,6 +63,10 @@ TF_RES_ID                 ?=
 TF_ENCRYPT_STATE          ?= false
 TF_ENCRYPT_METHOD         := sops
 
+### gcloud options
+
+GCLOUD_LAUNCH_BROWSER     ?=
+
 ### Google Cloud Platform
 
 GCP_DEFAULT_CONFIGURATION ?= 

--- a/tofu-gcp/Makefile
+++ b/tofu-gcp/Makefile
@@ -66,6 +66,10 @@ TF_ENCRYPT_METHOD         := tofu
 # Passphrase for the tofu-encrypted state
 TF_ENCRYPTION_PASSPHRASE  ?=
 
+### gcloud options
+
+GCLOUD_LAUNCH_BROWSER     ?=
+
 ### Google Cloud Platform
 
 GCP_DEFAULT_CONFIGURATION ?= 


### PR DESCRIPTION
Started getting some weird error from interactive login commands today (happens only on Linux...):

[237457:237457:0828/100833.755856:ERROR:components/sharing_message/sharing_service.cc:297] Device registration failed with fatal error [237499:237499:0828/100839.962848:ERROR:gpu/command_buffer/service/gles2_cmd_decoder_passthrough.cc:1096] [GroupMarkerNotSet(crbug.com/242999)/home/sergio/Projects/personal/devex-makefile/git st0301E00AC0C0000]Automatic fallback to software WebGL has been deprecated. Please use the --enable-unsafe-swiftshader (about:flags#enable-unsafe-swiftshader) flag to opt in to lower security guarantees for trusted content.

Enabling graphics acceleration in brave got rid of the second error, but the first one is still there.

In addition, it looks like the browser still runs in the background after the login is complete even if I close the tab, and no other tabs are open, which is a bit annoying.

Seems like using --no-launch-browser by default is a safer option to get rid of these issues.