### PR TITLE
(terraform/tofu): Distinguish between extra opts and args

### DIFF
--- a/base/tf.mk
+++ b/base/tf.mk
@@ -193,10 +193,10 @@ define tf
 				cmd+=("-refresh=true"); \
 			fi; \
 			if [ ! "$($@_OPTS)" = "" ]; then \
-				cmd+=("$($@_OPTS)"); \
+				cmd+=($($@_OPTS)); \
 			fi; \
 			if [ ! "$($@_ARGS)" = "" ]; then \
-				cmd+=("$($@_ARGS)"); \
+				cmd+=($($@_ARGS)); \
 			fi; \
 			if [ ! "$(TF_CONVERGE_FROM)" = "" ]; then \
 				_tmp_cmd=("$${cmd[@]}"); \
@@ -272,10 +272,10 @@ define tf
 		show|state|output) \
 			cmd=("$(_TF)" "$($@_CMD)"); \
 			if [ ! "$($@_OPTS)" = "" ]; then \
-				cmd+=("$($@_OPTS)"); \
+				cmd+=($($@_OPTS)); \
 			fi; \
 			if [ ! "$($@_ARGS)" = "" ]; then \
-				cmd+=("$($@_ARGS)"); \
+				cmd+=($($@_ARGS)); \
 			fi; \
 			if [ "$($@_CMD)" = "state" ]; then \
 				if [ ! "$(TF_RES_ADDR)" = "" ]; then \

--- a/terraform-gcp/Makefile
+++ b/terraform-gcp/Makefile
@@ -47,7 +47,9 @@ include $(__MAKE_DIR)../base/tf.mk
 ### Terraform|Tofu
 
 WORKSPACE                 ?=
-# Additional, space-separated, tofu command options
+# Additional, space-separated, terraform command options
+TF_OPTS                   ?=
+# Additional, space-separated, terraform command arguments
 TF_ARGS                   ?=
 # Set a resource path to apply first, before fully converging the entire configuration
 # This is a shortcut to avoid calling make apply twice, i.e. 'make apply TF_ARGS='-target="some_resource.name"' && make apply'

--- a/terraform-gcp/README.md
+++ b/terraform-gcp/README.md
@@ -91,8 +91,10 @@ Input variables for 'init' 🧮
 Input variables 🧮
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+<TF_OPTS>                      󱁢 Additional terraform command options
+                               (e.g., make apply TF_OPTS='-out=foo.out -lock=false')
 <TF_ARGS>                      󱁢 Additional terraform command arguments
-                               (e.g., make apply TF_ARGS='-out=foo.out -lock=false')
+                               (e.g., make output TF_OPTS='-raw' TF_ARGS='project_id')
 <TF_CONVERGE_FROM>             󱁢 Resource path to apply first
                                (before fully converging the entire configuration)
 <TF_PLAN>                      󱁢 terraform plan file path

--- a/tofu-gcp/Makefile
+++ b/tofu-gcp/Makefile
@@ -48,6 +48,8 @@ include $(__MAKE_DIR)../base/tf.mk
 
 WORKSPACE                 ?=
 # Additional, space-separated, tofu command options
+TF_OPTS                   ?=
+# Additional, space-separated, tofu command arguments
 TF_ARGS                   ?=
 # Set a resource path to apply first, before fully converging the entire configuration
 # This is a shortcut to avoid calling make apply twice, i.e. 'make apply TF_ARGS='-target="some_resource.name"' && make apply'

--- a/tofu-gcp/README.md
+++ b/tofu-gcp/README.md
@@ -92,8 +92,10 @@ Input variables for 'init' 🧮
 Input variables 🧮
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+<TF_OPTS>                       Additional tofu command options
+                               (e.g., make apply TF_OPTS='-out=foo.out -lock=false')
 <TF_ARGS>                       Additional tofu command arguments
-                               (e.g., make apply TF_ARGS='-out=foo.out -lock=false')
+                               (e.g., make output TF_OPTS='-raw' TF_ARGS='project_id')
 <TF_CONVERGE_FROM>              Resource path to apply first
                                (before fully converging the entire configuration)
 <TF_PLAN>                       tofu plan file path

--- a/tofu/Makefile
+++ b/tofu/Makefile
@@ -45,6 +45,8 @@ include $(__MAKE_DIR)../base/tf.mk
 
 WORKSPACE        ?=
 # Additional, space-separated, tofu command options
+TF_OPTS          ?=
+# Additional, space-separated, tofu command arguments
 TF_ARGS          ?=
 # Set a resource path to apply first, before fully converging the entire configuration
 # This is a shortcut to avoid calling make apply twice, i.e. 'make apply TF_ARGS='-target="some_resource.name"' && make apply'

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -82,8 +82,10 @@ Input variables for 'init' 🧮
 Input variables 🧮
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+<TF_OPTS>                       Additional tofu command options
+                               (e.g., make apply TF_OPTS='-out=foo.out -lock=false')
 <TF_ARGS>                       Additional tofu command arguments
-                               (e.g., make apply TF_ARGS='-out=foo.out -lock=false')
+                               (e.g., make output TF_OPTS='-raw' TF_ARGS='project_id')
 <TF_CONVERGE_FROM>              Resource path to apply first
                                (before fully converging the entire configuration)
 <TF_PLAN>                       tofu plan file path


### PR DESCRIPTION
Some commands like 'output' might require options to be declared separately from arguments, and squishing them all together resutls in errors.

For example 'tofu output -raw project_id' has '-raw' option, but 'project_id' argument, and placing both under TF_ARGS, results in 'project_id' being passed to '-raw' as a value